### PR TITLE
Allows to continue a cstar job by replaying the command on failed nodes

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -75,6 +75,8 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
     continue_parser = subparsers.add_parser('continue', help='Continue a previously created job (*)')
     continue_parser.set_defaults(func=execute_continue)
     continue_parser.add_argument('job_id')
+    continue_parser.add_argument('--retry-failed', action="store_true", default=False,
+                        help='Retry failed nodes.')
     _add_common_arguments(continue_parser)
     _add_cstar_arguments_without_command(continue_parser)
     _add_ssh_arguments(continue_parser)

--- a/cstar/cstarcli.py
+++ b/cstar/cstarcli.py
@@ -48,10 +48,11 @@ def get_commands():
 
 
 def execute_continue(args):
+    msg("Retry : ", args.retry_failed)
     with cstar.job.Job() as job:
         try:
             cstar.jobreader.read(job, args.job_id, args.stop_after, max_days=args.max_job_age,
-                                 output_directory=args.output_directory)
+                                 output_directory=args.output_directory, retry=args.retry_failed)
         except (FileTooOld, BadFileFormatVersion) as e:
             error(e)
         msg("Resuming job", job.job_id)

--- a/cstar/jobreader.py
+++ b/cstar/jobreader.py
@@ -24,7 +24,7 @@ from cstar.exceptions import BadFileFormatVersion, FileTooOld
 from cstar.output import debug
 
 
-def read(job, job_id, stop_after, output_directory=None, max_days=7, endpoint_mapper=None):
+def read(job, job_id, stop_after, output_directory=None, max_days=7, endpoint_mapper=None, retry=False):
     output_directory = output_directory or os.path.expanduser("~/.cstar/jobs/" + job_id)
     file = output_directory + "/job.json"
 
@@ -32,11 +32,11 @@ def read(job, job_id, stop_after, output_directory=None, max_days=7, endpoint_ma
         endpoint_mapper = job.get_endpoint_mapping
 
     with open(file) as f:
-        return _parse(f.read(), file, output_directory, job, job_id, stop_after, max_days, endpoint_mapper)
+        return _parse(f.read(), file, output_directory, job, job_id, stop_after, max_days, endpoint_mapper, retry)
     return job
 
 
-def _parse(input, file, output_directory, job, job_id, stop_after, max_days, endpoint_mapper):
+def _parse(input, file, output_directory, job, job_id, stop_after, max_days, endpoint_mapper, retry=False):
     data = json.loads(input)
 
     if 'version' not in data:
@@ -72,6 +72,9 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
         done=[cstar.topology.Host(*arr) for arr in state['progress']['done']],
         failed=[cstar.topology.Host(*arr) for arr in state['progress']['failed']])
 
+    if retry==True:
+        progress.failed = set([])
+    
     original_topology = cstar.topology.Topology(cstar.topology.Host(*arr) for arr in state['original_topology'])
     current_topology = cstar.topology.Topology(cstar.topology.Host(*arr) for arr in state['current_topology'])
 

--- a/tests/jobreader_test.py
+++ b/tests/jobreader_test.py
@@ -166,6 +166,30 @@ class JobReaderTest(unittest.TestCase):
             cstar.jobreader._parse(revised, "foo", "/somewhare", job, "1234", 5, 8,
                                    endpoint_mapper=lambda x: {})
 
+    def test_retry_failed_job(self):
+        job = cstar.job.Job()
+        job_id = "1234"
+        stop_after = 5
+        max_days = 999999
+        output_directory = "/som/dir"
+        filename = output_directory + "/some_file"
+        with open("tests/resources/failed_job.json", 'r') as f:
+            cstar.jobreader._parse(f.read(), "tests/resources/failed_job.json", output_directory, job, job_id, stop_after, max_days,
+                               endpoint_mapper=lambda x: {}, retry=False)
+            self.assertEqual(len(job.state.progress.failed), 1)
+        
+    def test_do_not_retry_failed_job(self):
+        job = cstar.job.Job()
+        job_id = "1234"
+        stop_after = 5
+        max_days = 999999
+        output_directory = "/som/dir"
+        filename = output_directory + "/some_file"
+        with open("tests/resources/failed_job.json", 'r') as f:
+            cstar.jobreader._parse(f.read(), "tests/resources/failed_job.json", output_directory, job, job_id, stop_after, max_days,
+                               endpoint_mapper=lambda x: {}, retry=True)
+            self.assertEqual(len(job.state.progress.failed), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/resources/failed_job.json
+++ b/tests/resources/failed_job.json
@@ -1,0 +1,94 @@
+{
+    "command": "/some/directory/commands/command.sh",
+    "creation_timestamp": 1508493330,
+    "env": {},
+    "errors": [],
+    "job_runner": "RemoteJobRunner",
+    "key_space": null,
+    "sleep_on_new_runner": 0.5,
+    "output_directory": "/some/directory/jobs/5ac35f50-5c20-45a2-9d22-1ec2e0b9d959",
+    "state": {
+        "cluster_parallel": true,
+        "current_topology": [
+            [
+                "host1",
+                "1.2.3.4",
+                "dc",
+                "cluster",
+                3074457345618258602,
+                true
+            ],
+            [
+                "host2",
+                "1.2.3.5",
+                "dc",
+                "cluster",
+                -3074457345618258603,
+                true
+            ],
+            [
+                "host3",
+                "1.2.3.6",
+                "dc",
+                "cluster",
+                -9223372036854775808,
+                true
+            ]
+        ],
+        "dc_parallel": true,
+        "progress" : {
+            "running": [],
+            "done": [
+                [
+                    "host1",
+                    "1.2.3.4",
+                    "dc",
+                    "cluster",
+                    3074457345618258602,
+                    true
+                ]
+            ],
+            "failed": [
+                [
+                    "host2",
+                    "1.2.3.5",
+                    "dc",
+                    "cluster",
+                    -3074457345618258603,
+                    true
+                ]
+            ]
+        },
+        "max_concurrency": null,
+        "original_topology": [
+            [
+                "host1",
+                "1.2.3.4",
+                "dc",
+                "cluster",
+                3074457345618258602,
+                true
+            ],
+            [
+                "host2",
+                "1.2.3.5",
+                "dc",
+                "cluster",
+                -3074457345618258603,
+                true
+            ],
+            [
+                "host3",
+                "1.2.3.6",
+                "dc",
+                "cluster",
+                -9223372036854775808,
+                true
+            ]
+        ],
+        "strategy": "topology",
+        "ignore_down_nodes": false
+    },
+    "timeout": null,
+    "version": 6
+}


### PR DESCRIPTION
Adds a `--retry-failed` flag to the `continue` command which will clean up the list of failed nodes in the progress object. 
Allows to retry all failed nodes on failed jobs when using `continue`.