### PR TITLE
Reduce verbosity of DNS preheating for IPs without a reverse DNS entry

### DIFF
--- a/cstar/job.py
+++ b/cstar/job.py
@@ -107,8 +107,14 @@ class Job(object):
             return
         self.is_preheated = True
 
+        def get_host_by_addr(ip):
+            try:
+                socket.gethostbyaddr(ip)
+            except socket.herror:
+                pass
+
         def create_lookup_thread(ip):
-            return threading.Thread(target=lambda: socket.gethostbyaddr(ip))
+            return threading.Thread(target=get_host_by_addr, args=[ip])
 
         print("Preheating DNS cache")
         threads = [create_lookup_thread(ip) for ip in ips]

--- a/cstar/job.py
+++ b/cstar/job.py
@@ -114,7 +114,7 @@ class Job(object):
                 pass
 
         def create_lookup_thread(ip):
-            return threading.Thread(target=get_host_by_addr, args=[ip])
+            return threading.Thread(target=lambda: get_host_by_addr(ip))
 
         print("Preheating DNS cache")
         threads = [create_lookup_thread(ip) for ip in ips]


### PR DESCRIPTION
My current Cassandra cluster doesn't have reverse DNS entries. As such the console is cluttered with exceptions like this one:

```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/home/reynald/.local/lib/python3.4/site-packages/cstar/job.py", line 117, in <lambda>
    return threading.Thread(target=lambda: socket.gethostbyaddr(ip))
socket.herror: [Errno 1] Unknown host
```

Here is a proposal to reduce this logging.

It's been a long time I haven't written python code so let me also know if there is a better way to achieve this change :wink: .
