### PR TITLE
Revert default ssh lib to paramiko as ssh2 cannot handle sudo commands

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -38,7 +38,7 @@ def _add_destination_arguments(parser):
                         help='The amount of time to pause between establishing new ssh connections to avoid timeouts')
     parser.add_argument('--node-done-pause-time', type=float, default=0.0,
                         help='The amount of time (in seconds) to pause between a node has finished and the next node starting')
-    parser.add_argument('--ssh-lib', type=str, default="ssh2",
+    parser.add_argument('--ssh-lib', type=str, default="paramiko",
                         help='SSH library to use for remote connections')
 
 


### PR DESCRIPTION
As stated in #30, we'd better revert the default to `paramiko` as `ssh2-python` doesn't allow `sudo` commands, which could prevent operations as rolling restarts.