### PR TITLE
add support for JMX authentication

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -83,12 +83,14 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
     _add_common_arguments(continue_parser)
     _add_cstar_arguments_without_command(continue_parser)
     _add_ssh_arguments(continue_parser)
+    _add_jmx_auth_arguments(continue_parser)
 
     cleanup_parser = subparsers.add_parser('cleanup-jobs', help='Cleanup old finished jobs and exit (*)')
     cleanup_parser.set_defaults(func=execute_cleanup)
     _add_common_arguments(cleanup_parser)
     _add_cstar_arguments_without_command(cleanup_parser)
     _add_ssh_arguments(cleanup_parser)
+    _add_jmx_auth_arguments(cleanup_parser)
 
     for (name, command) in commands.items():
         command_parser = subparsers.add_parser(name, help=command.description)
@@ -98,6 +100,7 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
         _add_strategy_arguments(command_parser)
         _add_common_arguments(command_parser)
         _add_ssh_arguments(command_parser)
+        _add_jmx_auth_arguments(command_parser)
         command_parser.set_defaults(func=lambda args: execute_command(args), command=command)
 
 
@@ -107,10 +110,13 @@ def add_cstarpar_arguments(parser):
     _add_common_arguments(parser)
     _add_strategy_arguments(parser)
     _add_ssh_arguments(parser)
+    _add_jmx_auth_arguments(parser)
     parser.add_argument('command', help='Command to run once for each Cassandra host')
 
 def _add_ssh_arguments(parser):
     parser.add_argument('--ssh-username', help='Username for ssh connection', default=None)
     parser.add_argument('--ssh-password', help='Password for ssh connection', default=None)
     parser.add_argument('--ssh-identity-file', help='Identity file for ssh connection', default=None)
-    
+
+def _add_jmx_auth_arguments(parser):
+    parser.add_argument('--jmx-username', help='JMX username', default=None)

--- a/cstar/cstarparcli.py
+++ b/cstar/cstarparcli.py
@@ -15,6 +15,7 @@
 """Argument parsing and related plumbing for the cstarpar command"""
 
 import argparse
+import getpass
 import sys
 import uuid
 
@@ -47,6 +48,11 @@ def parse_job_mode():
 
 def main():
     namespace = parse_job_mode()
+
+    if namespace.jmx_username:
+        namespace.jmx_password = getpass.getpass(prompt="JMX Password ")
+    else:
+        namespace.jmx_password = None
 
     if bool(namespace.seed_host) + bool(namespace.host) + bool(namespace.host_file) != 1:
         error("Exactly one of --seed-host, --host and --host-file must be used", print_traceback=False)
@@ -91,7 +97,9 @@ def main():
             ssh_username = namespace.ssh_username,
             ssh_password = namespace.ssh_password,
             ssh_identity_file = namespace.ssh_identity_file,
-            ssh_lib=namespace.ssh_lib)
+            ssh_lib=namespace.ssh_lib,
+            jmx_username=namespace.jmx_username,
+            jmx_password=namespace.jmx_password)
         job.run()
 
 

--- a/cstar/jobreader.py
+++ b/cstar/jobreader.py
@@ -65,6 +65,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
     job.ssh_identity_file = data['ssh_identity_file']
     job.ssh_password = data['ssh_password']
     job.ssh_lib = data['ssh_lib']
+    job.jmx_username = data['jmx_username']
 
     strategy = cstar.strategy.parse(state['strategy'])
     cluster_parallel = state['cluster_parallel']

--- a/cstar/jobwriter.py
+++ b/cstar/jobwriter.py
@@ -55,7 +55,7 @@ def _progress_to_dict(self):
 
 
 def _job_to_dict(self):
-    skip = {"results", "handled_finished_jobs", "do_loop", "job_id", "job_runner"}
+    skip = {"results", "handled_finished_jobs", "do_loop", "job_id", "job_runner", "jmx_password"}
     data = dict((key, _to_dict(val)) for key, val in self.__dict__.items() if key[0] != '_' and key not in skip)
     data["version"] = FILE_FORMAT_VERSION
     data["job_runner"] = self.job_runner.__name__


### PR DESCRIPTION
This is a PR for issue [33](https://github.com/spotify/cstar/issues/33). Flags are added for JMX username/password. Below is example usage:

`$ cstar run --command="nodetool -u cassandra -pw cassandra status" --strategy=all --seed-host=1.2.3.4 --ssh-username=ubuntu --jmx-username=cassandra --jmx-password=cassandra`