### PR TITLE
Fix topology with multiple clusters

### DIFF
--- a/cstar/endpoint_mapping.py
+++ b/cstar/endpoint_mapping.py
@@ -55,6 +55,7 @@ def _topology_map(mapping, topology):
     for raw_host, raw_friends in mapping.items():
         friends = (topology.get_host(raw_friend) for raw_friend in raw_friends)
         host = topology.get_host(raw_host)
-        filtered_friends = set(friend for friend in friends if friend.dc == host.dc)
+        filtered_friends = set(friend for friend in friends
+                               if friend.cluster == host.cluster and friend.dc == host.dc)
         res[host] = filtered_friends
     return res

--- a/cstar/strategy.py
+++ b/cstar/strategy.py
@@ -53,8 +53,7 @@ def find_next_host(strategy, topology, endpoint_mapping, progress, cluster_paral
         remaining = remaining.with_cluster(next(iter(progress.running)).cluster)
 
     if progress.running and not dc_parallel:
-        running_host = next(iter(progress.running))
-        remaining = remaining.with_dc(running_host.cluster, running_host.dc)
+        remaining = remaining.with_dc_or_distinct_cluster(progress.running)
 
     if not remaining:
         return None

--- a/cstar/topology.py
+++ b/cstar/topology.py
@@ -59,6 +59,14 @@ class Topology(object):
         """Return subtopology filtered on pair cluster/dc for uniqness concerns"""
         return Topology(filter(lambda host: dc == host.dc and cluster == host.cluster, self.hosts))
 
+    def with_dc_or_distinct_cluster(self, hosts=None):
+        """Return subtopology with DCs of passed hosts or DCs in a distinct cluster"""
+        all_dcs = self.get_dcs()
+        running_dcs = self.get_dcs(hosts)
+        clusters = set(cluster_dc.cluster for cluster_dc in running_dcs)
+        return Topology(filter(lambda host: Datacenter(host.cluster, host.dc) in running_dcs
+                                      or host.cluster not in clusters, self.hosts))
+
     def with_dc_filter(self, dc):
         """Retrun subtopology filtered on dc only dc is used,
            if clusters share a DC name, all clusters will be considered


### PR DESCRIPTION
- Parallel clusters should allow distinct DC to run in parallel as long as they are in distinct clusters, only considering the `--cluster-parallel` option, no matter if `--dc-serial` flag is set.
- When running 2 or more cluster at once, topology was not respected and multiple nodes could run at once, despite being neighbours (or 'friends' in cstar code) to each other. 
The problem is that mapping is made using only one node. When 2 seeds of 2 distinct clusters are passed, some endpoints would not be calculated. The PR Fixes this.