### PR TITLE
Store & pass dc_filter when resuming jobs

### DIFF
--- a/cstar/job.py
+++ b/cstar/job.py
@@ -214,7 +214,7 @@ class Job(object):
                 current_topology = current_topology | self.get_cluster_topology((seed,))
             original_topology = current_topology
             if dc_filter:
-                original_topology = original_topology.with_dc(dc_filter)
+                original_topology = original_topology.with_dc_filter(dc_filter)
         else:
             current_topology = cstar.topology.Topology()
             hosts_ip_set = set(socket.gethostbyname(host) for host in hosts)
@@ -237,9 +237,10 @@ class Job(object):
             endpoint_mapping = None
             msg("Skipping endpoint mapping because of selected strategy")
 
-        self.state = cstar.state.State(original_topology, strategy, endpoint_mapping, cluster_parallel, dc_parallel,
-                                       max_concurrency, current_topology=current_topology, stop_after=stop_after,
-                                       ignore_down_nodes=ignore_down_nodes)
+        self.state = cstar.state.State(original_topology, strategy, endpoint_mapping,
+                                       cluster_parallel, dc_parallel, dc_filter=dc_filter,
+                                       max_concurrency=max_concurrency, current_topology=current_topology,
+                                       stop_after=stop_after, ignore_down_nodes=ignore_down_nodes)
         msg("Setup done")
 
     def update_current_topology(self, skip_nodes=()):

--- a/cstar/jobreader.py
+++ b/cstar/jobreader.py
@@ -70,6 +70,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
     strategy = cstar.strategy.parse(state['strategy'])
     cluster_parallel = state['cluster_parallel']
     dc_parallel = state['dc_parallel']
+    dc_filter = state['dc_filter'] if 'dc_filter' in state else None
     max_concurrency = state['max_concurrency']
 
     progress = cstar.progress.Progress(
@@ -79,7 +80,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
 
     if retry==True:
         progress.failed = set([])
-    
+
     original_topology = cstar.topology.Topology(cstar.topology.Host(*arr) for arr in state['original_topology'])
     current_topology = cstar.topology.Topology(cstar.topology.Host(*arr) for arr in state['current_topology'])
 
@@ -97,6 +98,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
         endpoint_mapping=endpoint_mapping,
         cluster_parallel=cluster_parallel,
         dc_parallel=dc_parallel,
+        dc_filter=dc_filter,
         max_concurrency=max_concurrency,
         current_topology=current_topology,
         stop_after=stop_after,

--- a/cstar/state.py
+++ b/cstar/state.py
@@ -31,15 +31,15 @@ class State(object):
     This type is meant to be used without mutating it."""
 
     def __init__(
-            self, original_topology, strategy, endpoint_mapping, cluster_parallel, dc_parallel,
-            max_concurrency=None, progress=None, current_topology=None, stop_after=None,
-            ignore_down_nodes=False):
+            self, original_topology, strategy, endpoint_mapping, cluster_parallel, dc_parallel, dc_filter=None,
+            max_concurrency=None, progress=None, current_topology=None, stop_after=None, ignore_down_nodes=False):
         self.original_topology = original_topology
         self.current_topology = current_topology or original_topology
         self.strategy = strategy
         self.endpoint_mapping = endpoint_mapping
         self.cluster_parallel = cluster_parallel
         self.dc_parallel = dc_parallel
+        self.dc_filter = dc_filter
         self.max_concurrency = max_concurrency
         self.progress = progress or cstar.progress.Progress()
         self.stop_after = stop_after

--- a/tests/jobreader_test.py
+++ b/tests/jobreader_test.py
@@ -48,6 +48,8 @@ def get_example_file():
     "ssh_lib": "paramiko",
     "state": {
         "cluster_parallel": true,
+        "dc_parallel": true,
+        "dc_filter": "gew",
         "current_topology": [
             [
                 "host1",
@@ -74,7 +76,6 @@ def get_example_file():
                 true
             ]
         ],
-        "dc_parallel": true,
         "progress" : {
             "running": [],
             "done": [
@@ -156,6 +157,10 @@ class JobReaderTest(unittest.TestCase):
         self.assertEqual(len(job.state.current_topology), 3)
         self.assertEqual(len(job.state.original_topology), 3)
         self.assertEqual(type(job.state.original_topology.first()), cstar.topology.Host)
+        # Check options are passed:
+        self.assertEqual(job.state.cluster_parallel, True)
+        self.assertEqual(job.state.dc_parallel, True)
+        self.assertEqual(job.state.dc_filter, "gew")
 
     def test_old_job(self):
         job = cstar.job.Job()
@@ -182,7 +187,7 @@ class JobReaderTest(unittest.TestCase):
             cstar.jobreader._parse(f.read(), "tests/resources/failed_job.json", output_directory, job, job_id, stop_after, max_days,
                                endpoint_mapper=lambda x: {}, retry=False)
             self.assertEqual(len(job.state.progress.failed), 1)
-        
+
     def test_do_not_retry_failed_job(self):
         job = cstar.job.Job()
         job_id = "1234"

--- a/tests/strategy_test.py
+++ b/tests/strategy_test.py
@@ -82,7 +82,7 @@ class StrategyTest(unittest.TestCase):
 
     def test_max_concurrency(self):
         top = make_topology(size=3)
-        state = State(top, Strategy.ALL, None, True, True, 10)
+        state = State(top, Strategy.ALL, None, True, True, max_concurrency=10)
         state = add_work(state)
         self.assertEqual(len(state.progress.running), 10)
 


### PR DESCRIPTION
When resuming a job, the `dc_filter` option was not passed to the new job. It should be.

- Now storing the `dc_filter` option in job.json
- When using `cstar continue xxx`, the `dc_filter` option is acknowledged
- Tests were updated.