### PR TITLE
allow agent forwarding

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -117,6 +117,7 @@ def _add_ssh_arguments(parser):
     parser.add_argument('--ssh-username', help='Username for ssh connection', default=None)
     parser.add_argument('--ssh-password', help='Password for ssh connection', default=None)
     parser.add_argument('--ssh-identity-file', help='Identity file for ssh connection', default=None)
+    parser.add_argument('--ssh-allow-agent', help='Allow loading ssh keys from agent', action='store_true', default=False)
 
 def _add_jmx_auth_arguments(parser):
     parser.add_argument('--jmx-username', help='JMX username', default=None)

--- a/cstar/cstarcli.py
+++ b/cstar/cstarcli.py
@@ -125,7 +125,8 @@ def execute_command(args):
             ssh_identity_file=args.ssh_identity_file,
             ssh_lib=args.ssh_lib,
             jmx_username=args.jmx_username,
-            jmx_password=args.jmx_password)
+            jmx_password=args.jmx_password,
+            ssh_allow_agent=args.ssh_allow_agent)
         job.run()
 
 def validate_uuid4(uuid_string):

--- a/cstar/cstarparcli.py
+++ b/cstar/cstarparcli.py
@@ -99,7 +99,8 @@ def main():
             ssh_identity_file = namespace.ssh_identity_file,
             ssh_lib=namespace.ssh_lib,
             jmx_username=namespace.jmx_username,
-            jmx_password=namespace.jmx_password)
+            jmx_password=namespace.jmx_password,
+            ssh_allow_agent=args.ssh_allow_agent)
         job.run()
 
 

--- a/cstar/job.py
+++ b/cstar/job.py
@@ -69,6 +69,7 @@ class Job(object):
         self.ssh_identity_file = None
         self.jmx_username = None
         self.jmx_password = None
+        self.ssh_allow_agent = None
         self.returned_jobs = list()
 
     def __enter__(self):
@@ -187,7 +188,7 @@ class Job(object):
               ignore_down_nodes, dc_filter,
               sleep_on_new_runner, sleep_after_done,
               ssh_username, ssh_password, ssh_identity_file, ssh_lib,
-              jmx_username, jmx_password):
+              jmx_username, jmx_password, ssh_allow_agent):
 
         msg("Starting setup")
 
@@ -210,6 +211,7 @@ class Job(object):
         self.ssh_lib = ssh_lib
         self.jmx_username = jmx_username
         self.jmx_password = jmx_password
+        self.ssh_allow_agent = ssh_allow_agent
         if not os.path.exists(self.output_directory):
             os.makedirs(self.output_directory)
 
@@ -395,13 +397,13 @@ class Job(object):
 
     def schedule_job(self, host):
         debug("Running on host", host.fqdn)
-        threading.Thread(target=self.job_runner(self, host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib),
+        threading.Thread(target=self.job_runner(self, host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib, self.ssh_allow_agent),
                          name="cstar %s" % host.fqdn).start()
         time.sleep(self.sleep_on_new_runner)
 
     def _connection(self, host):
         if host not in self._connections:
-            self._connections[host] = cstar.remote.Remote(host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib)
+            self._connections[host] = cstar.remote.Remote(host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib, self.ssh_allow_agent)
         return self._connections[host]
 
     def close(self):

--- a/cstar/jobrunner.py
+++ b/cstar/jobrunner.py
@@ -47,16 +47,17 @@ class RemoteJobRunner(object):
     This JobRunner is used by cstar
     """
 
-    def __init__(self, job, host, ssh_username, ssh_password, ssh_identity_file, ssh_lib):
+    def __init__(self, job, host, ssh_username, ssh_password, ssh_identity_file, ssh_lib, ssh_allow_agent):
         self.job = job
         self.host = host
         self.ssh_username = ssh_username
         self.ssh_password = ssh_password
         self.ssh_identity_file = ssh_identity_file
         self.ssh_lib = ssh_lib
+        self.ssh_allow_agent = ssh_allow_agent
 
     def __call__(self):
-        with cstar.remote.Remote(self.host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib) as conn:
+        with cstar.remote.Remote(self.host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib, self.ssh_allow_agent) as conn:
             result = conn.run_job(self.job.command, self.job.job_id, self.job.timeout, self.job.env)
             self.job.results.put((self.host, result))  # This signals the main thread that the job completed.
             save_output(self.job, self.host, result)

--- a/cstar/remote.py
+++ b/cstar/remote.py
@@ -17,9 +17,9 @@ from cstar.output import debug
 from cstar.exceptions import BadArgument
 
 class Remote(object):
-    def __init__(self, hostname, ssh_username, ssh_password, ssh_identity_file, ssh_lib):
+    def __init__(self, hostname, ssh_username, ssh_password, ssh_identity_file, ssh_lib, ssh_allow_agent):
         debug("Using ssh lib : ", ssh_lib)
-        self.remote = RemoteParamiko(hostname, ssh_username, ssh_password, ssh_identity_file)
+        self.remote = RemoteParamiko(hostname, ssh_username, ssh_password, ssh_identity_file, ssh_allow_agent)
 
     def __enter__(self):
         return self

--- a/cstar/remote_paramiko.py
+++ b/cstar/remote_paramiko.py
@@ -26,7 +26,7 @@ _alnum_re = re.compile(r"[^a-zA-Z0-9\|_]")
 
 
 class RemoteParamiko(object):
-    def __init__(self, hostname, ssh_username=None, ssh_password=None, ssh_identity_file=None):
+    def __init__(self, hostname, ssh_username=None, ssh_password=None, ssh_identity_file=None, ssh_allow_agent=False):
         if hasattr(hostname, "ip"):
             self.hostname = hostname.ip
         else:
@@ -36,6 +36,7 @@ class RemoteParamiko(object):
         self.ssh_username = ssh_username
         self.ssh_password = ssh_password
         self.ssh_identity_file = ssh_identity_file
+        self.ssh_allow_agent = ssh_allow_agent
         self.client = None
 
     def __enter__(self):
@@ -63,7 +64,7 @@ class RemoteParamiko(object):
                 debug("Username : ", self.ssh_username)
                 debug("Id file: ", self.ssh_identity_file)
                 self.client.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
-                self.client.connect(self.hostname, compress=True, username=self.ssh_username, password=self.ssh_password, pkey=pkey)
+                self.client.connect(self.hostname, compress=True, allow_agent=self.ssh_allow_agent, username=self.ssh_username, password=self.ssh_password, pkey=pkey)
             except:
                 self.client = None
                 raise BadSSHHost("Could not establish an SSH connection to host %s" % (self.hostname,))


### PR DESCRIPTION
Allow loading ssh-keys from a forwarded ssh-agent.

This allows us to install cstar on a bastion without ssh keys and use ssh agent forwarding to then connect to nodes internal to the cluster.
