### PR TITLE
Improve performance of "Preheating DNS cache" phase when running against clusters with vnodes enabled

### DIFF
--- a/cstar/job.py
+++ b/cstar/job.py
@@ -120,7 +120,7 @@ class Job(object):
             return threading.Thread(target=lambda: get_host_by_addr(ip))
 
         print("Preheating DNS cache")
-        threads = [create_lookup_thread(ip) for ip in ips]
+        threads = [create_lookup_thread(ip) for ip in set(ips)]
 
         for thread in threads:
             thread.start()


### PR DESCRIPTION
This PR improves the performance and avoids errors caused by excessive reverse DNS lookups when running against clusters with vnodes enabled.

# Background

As part of determining the cluster topology ("Loading cluster topology" phase), cstar uses `nodetool ring` to get a list of tokens.

`cstar` then retries to warm the dns caches by iterating through all the tokens returned and doing reverse dns lookups on each entry.

Unfortunately, this is very inefficient when you have vnodes enabled. If you use the default of 256 vnodes per host, then cstar is effectively doing 256 DNS lookups per host (but really, only a single lookup per host should be needed).

DNS lookups are typically fast, so doing 256x lookups isn't particularly noticeable. However, cstar tries to do every single lookup in parallel. This means that you can easily hit resource limits (like hitting max thread limits), which can cause lead to errors.

# Example error

```
Traceback (most recent call last):
  File "/usr/local/bin/cstar", line 11, in <module>
    load_entry_point('cstar', 'console_scripts', 'cstar')()
  File "/Users/matt.jurik/Documents/development/cstar/cstar/cstarcli.py", line 132, in main
    namespace.func(namespace)
  File "/Users/matt.jurik/Documents/development/cstar/cstar/args.py", line 100, in <lambda>
    command_parser.set_defaults(func=lambda args: execute_command(args), command=command)
  File "/Users/matt.jurik/Documents/development/cstar/cstar/cstarcli.py", line 116, in execute_command
    ssh_lib=args.ssh_lib)
  File "/Users/matt.jurik/Documents/development/cstar/cstar/job.py", line 203, in setup
    current_topology = current_topology | self.get_cluster_topology((seed,))
  File "/Users/matt.jurik/Documents/development/cstar/cstar/job.py", line 97, in get_cluster_topology
    topology = cstar.nodetoolparser.parse_nodetool_ring(topology_res.out, cluster_name, self.reverse_dns_preheat)
  File "/Users/matt.jurik/Documents/development/cstar/cstar/nodetoolparser/simple.py", line 50, in parse_nodetool_ring
    reverse_dns_preheat([node[0] for (_, nodes) in datacenter_names_and_nodes for node in nodes])
  File "/Users/matt.jurik/Documents/development/cstar/cstar/job.py", line 124, in reverse_dns_preheat
    thread.start()
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 852, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't start new thread
```