### PR TITLE
Reorder usage of recv_exit_status to avoid connection hangs

### DIFF
--- a/cstar/remote_paramiko.py
+++ b/cstar/remote_paramiko.py
@@ -117,9 +117,9 @@ class RemoteParamiko(object):
             cmd = " ".join(self.escape(s) for s in argv)
 
             stdin, stdout, stderr = self.client.exec_command(cmd)
-            status = stdout.channel.recv_exit_status()
             out = stdout.read()
             error = stderr.read()
+            status = stdout.channel.recv_exit_status()
             if status != 0:
                 err("Command %s failed with status %d on host %s" % (cmd, status, self.hostname))
             else:


### PR DESCRIPTION
This PR fixes an issue where commands that return large amounts of output (such as `nodetool describering <keyspace>` as needed during the "Generating endpoint mapping" phase when running with `--strategy=topology`) can appear to hang indefinitely.

The `recv_exit_status()` paramiko function offers a warning about this situation:
https://github.com/paramiko/paramiko/blob/2.3.3/paramiko/channel.py#L379