### PR TITLE
Update paramiko to 2.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paramiko==2.3.3
+paramiko==2.7.1

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='cstar',
           'Programming Language :: Python :: 3.6',
           'Topic :: Database'
       ],
-      install_requires=['paramiko==2.3.3'],
+      install_requires=['paramiko==2.7.1'],
       python_requires='>=3',
       packages=('cstar', 'cstar.nodetoolparser', 'cstar.resources'),
       package_data={'cstar.resources': ['commands/*', 'scripts/*']},


### PR DESCRIPTION
This PR bumps the version of paramiko from 2.3.3 to 2.7.1 (latest at time of writing).

Paramiko 2.3.3 uses some deprecated cryptography module functions and reports the following warnings:
```
/usr/local/lib/python3.7/site-packages/paramiko/kex_ecdh_nist.py:39: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.
  m.add_string(self.Q_C.public_numbers().encode_point())
/usr/local/lib/python3.7/site-packages/paramiko/kex_ecdh_nist.py:94: CryptographyDeprecationWarning: Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point
  self.curve, Q_S_bytes
/usr/local/lib/python3.7/site-packages/paramiko/kex_ecdh_nist.py:109: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.
  hm.add_string(self.Q_C.public_numbers().encode_point())
```

By upgrading paramiko to the latest version, we no longer see these these warnings.