### PR TITLE
Fix regex for rack string to include dashes

### DIFF
--- a/cstar/nodetoolparser/status.py
+++ b/cstar/nodetoolparser/status.py
@@ -23,7 +23,7 @@ _load_re = re.compile(r"^(([0-9]+([,.][0-9]+)?)(\s+)([a-zA-Z]{1,2}))$")
 _tokens_re = re.compile(r"^\d+$")
 _owns_re = re.compile(r"^\d+\.\d+\%$")
 _host_id_re = re.compile(r"^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$")
-_rack_re = re.compile(r"^(?=.*-)[\w -]+$")
+_rack_re = re.compile(r"^(?=.*)[\w -]+$")
 _keyspace_name_re = re.compile(r"^\s*Keyspace\s*:\s*(.*)$", re.MULTILINE)
 
 

--- a/cstar/nodetoolparser/status.py
+++ b/cstar/nodetoolparser/status.py
@@ -23,7 +23,7 @@ _load_re = re.compile(r"^(([0-9]+([,.][0-9]+)?)(\s+)([a-zA-Z]{1,2}))$")
 _tokens_re = re.compile(r"^\d+$")
 _owns_re = re.compile(r"^\d+\.\d+\%$")
 _host_id_re = re.compile(r"^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$")
-_rack_re = re.compile(r"^\w+$")
+_rack_re = re.compile(r"^(?=.*-)[\w -]+$")
 _keyspace_name_re = re.compile(r"^\s*Keyspace\s*:\s*(.*)$", re.MULTILINE)
 
 


### PR DESCRIPTION
When using AWS AZs for rack names in C*, it just breaks the nodetool status parser. Example nodetool status output:

```
# nodetool status
Datacenter: us-east-1
=====================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address        Load       Tokens       Owns    Host ID                               Rack
UN  10.14.42.100   2.83 MiB   4            ?       c59cf257-8528-419a-ba8d-51119da065f9  us-east-1a
UN  10.14.170.146  2.82 MiB   4            ?       dc480650-5e87-4c62-80f6-15aa4c9b1c95  us-east-1c
UN  10.14.108.80   2.86 MiB   4            ?       800ff299-388b-40aa-8946-6b558baa8b12  us-east-1b
Datacenter: us-east-2
=====================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address        Load       Tokens       Owns    Host ID                               Rack
UN  10.11.170.146  3.47 MiB   4            ?       4a7d4e87-4636-43c2-8bf7-cb3ce0f42e9c  us-east-2c
UN  10.11.108.80   3.55 MiB   4            ?       2eaf38d5-2fe8-4cb4-a4ac-b99aa6169bf6  us-east-2b
UN  10.11.42.100   3.62 MiB   4            ?       dd8a14f1-83b9-46dd-bfc7-8e7547b3b353  us-east-2a
```

I know there's an existing issue https://github.com/spotify/cstar/issues/39 where it points to a similar problem, but looks like is quite old and the referenced code has changed too.