### PR TITLE
Correctly process --hosts-variables argument in cstarpar

### DIFF
--- a/cstar/cstarparcli.py
+++ b/cstar/cstarparcli.py
@@ -16,6 +16,7 @@
 
 import argparse
 import getpass
+import json
 import sys
 import uuid
 
@@ -68,6 +69,12 @@ def main():
 
     cstar.output.configure(namespace.verbose)
 
+    hosts_variables = dict()
+
+    if namespace.hosts_variables:
+        with open(namespace.hosts_variables) as f:
+            hosts_variables = json.loads(f.read())
+
     with cstar.job.Job() as job:
         env = {}
         job_id = str(uuid.uuid4())
@@ -101,7 +108,7 @@ def main():
             jmx_username=namespace.jmx_username,
             jmx_password=namespace.jmx_password,
             resolve_hostnames=namespace.resolve_hostnames,
-            hosts_variables=namespace.hosts_variables)
+            hosts_variables=hosts_variables)
         job.run()
 
 


### PR DESCRIPTION
cstarpar does not correctly process the `--hosts-variables` argument. If it is not specified, this leads to an exception when executing the job:

```
Job id is e9f070ff-194e-4e2b-878a-2ab1998534bc
Starting setup
Strategy: topology
Cluster parallel: False
DC parallel: False
Loading cluster topology
Traceback (most recent call last):
  File "/usr/bin/cstarpar", line 11, in <module>
    load_entry_point('cstar==0.8.1', 'console_scripts', 'cstarpar')()
  File "/usr/lib/python3/dist-packages/cstar/cstarparcli.py", line 104, in main
    hosts_variables=namespace.hosts_variables)
  File "/usr/lib/python3/dist-packages/cstar/job.py", line 271, in setup
    current_topology = current_topology | self.get_cluster_topology(seeds)
  File "/usr/lib/python3/dist-packages/cstar/job.py", line 105, in get_cluster_topology
    conn = self._connection(host)
  File "/usr/lib/python3/dist-packages/cstar/job.py", line 456, in _connection
    self._connections[host] = cstar.remote.Remote(host, self.ssh_username, self.ssh_password, self.ssh_identity_file, self.ssh_lib, self.get_host_variables(host))
  File "/usr/lib/python3/dist-packages/cstar/job.py", line 471, in get_host_variables
    if hostname in self.hosts_variables.keys():
AttributeError: 'NoneType' object has no attribute 'keys'
```

If the option is specified, this exception is avoided, but instead of loading the variables from the specified files, the parameters are used “as-is”.

This PR fixes this issue by making the cstarpar command process the `--hosts-variables` argument in the same way as the `cstar` command.

This PR fixes #68.