### PR TITLE
Add additional jmx args to nodetool as required

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -140,3 +140,4 @@ def _add_ssh_arguments(parser):
 def _add_jmx_auth_arguments(parser):
     parser.add_argument('--jmx-username', help='JMX username', default=None)
     parser.add_argument('--jmx-passwordfile', help='JMX passwordfile', default=None)
+    parser.add_argument('--jmx-addlargs', help='JMX args passed to nodetool', default=None)

--- a/cstar/cstarcli.py
+++ b/cstar/cstarcli.py
@@ -142,6 +142,7 @@ def execute_command(args):
             jmx_username=args.jmx_username,
             jmx_password=args.jmx_password,
             jmx_passwordfile=args.jmx_passwordfile,
+            addl_jmx_args=args.jmx_addlargs,
             resolve_hostnames=args.resolve_hostnames,
             hosts_variables=hosts_variables)
         job.run()

--- a/cstar/job.py
+++ b/cstar/job.py
@@ -76,6 +76,7 @@ class Job(object):
         self.jmx_username = None
         self.jmx_password = None
         self.jmx_passwordfile = None
+        self.addl_jmx_args = None
         self.hosts_variables = dict()
         self.returned_jobs = list()
         self.schema_versions = list()
@@ -240,7 +241,10 @@ class Job(object):
                 jmx_args.extend(["-pw", self.jmx_password])
             if self.jmx_passwordfile:
                 jmx_args.extend(["-pwf", self.jmx_passwordfile])
-
+        if self.addl_jmx_args:
+            self.addl_jmx_args = self.addl_jmx_args.replace('\\','')
+            jmx_args.extend([self.addl_jmx_args])
+            
         return conn.run((*sudo, "nodetool", *jmx_args, *cmds))
 
     def setup(self, hosts, seeds, command, job_id, strategy, cluster_parallel, dc_parallel, job_runner,
@@ -248,7 +252,8 @@ class Job(object):
               ignore_down_nodes, dc_filter,
               sleep_on_new_runner, sleep_after_done,
               ssh_username, ssh_password, ssh_identity_file, ssh_lib,
-              jmx_username, jmx_password, jmx_passwordfile, resolve_hostnames, hosts_variables):
+              jmx_username, jmx_password, jmx_passwordfile, addl_jmx_args, 
+              resolve_hostnames, hosts_variables):
 
         msg("Starting setup")
 
@@ -275,6 +280,7 @@ class Job(object):
         self.jmx_username = jmx_username
         self.jmx_password = jmx_password
         self.jmx_passwordfile = jmx_passwordfile
+        self.addl_jmx_args = addl_jmx_args
         self.resolve_hostnames = resolve_hostnames
         self.hosts_variables = hosts_variables
         if not os.path.exists(self.output_directory):

--- a/cstar/jobreader.py
+++ b/cstar/jobreader.py
@@ -69,6 +69,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
     job.sudo_args = data['sudo_args']
     job.jmx_username = data['jmx_username']
     job.jmx_passwordfile = data['jmx_passwordfile']
+    job.addl_jmx_args = data['addl_jmx_args']
     job.hosts_variables = data['hosts_variables']
 
     strategy = cstar.strategy.parse(state['strategy'])

--- a/tests/jobreader_test.py
+++ b/tests/jobreader_test.py
@@ -140,6 +140,7 @@ def get_example_file():
     "timeout": null,
     "jmx_username": null,
     "jmx_passwordfile": null,
+    "addl_jmx_args": null,
     "use_sudo": "false",
     "version": 8,
     "hosts_variables": null

--- a/tests/resources/failed_job.json
+++ b/tests/resources/failed_job.json
@@ -105,6 +105,7 @@
     "timeout": null,
     "jmx_username": null,
     "jmx_passwordfile": null,
+    "addl_jmx_args": null,
     "use_sudo": false,
     "version": 8,
     "hosts_variables": null


### PR DESCRIPTION
Allows the passing of additional jmx args to nodetool
eg `--jmx-addlargs '\-Dcom.sun.jndi.rmiURLParsing=legacy'`

This allows a workaround between newer java versions and older cassandra versions
see
https://stackoverflow.com/questions/72258217/cassandra-nodetool-urisyntaxexception-malformed-ipv6-address-at-index-7
