### PR TITLE
allow setting arbitrary jmx args

### DIFF
--- a/cstar/args.py
+++ b/cstar/args.py
@@ -103,6 +103,7 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
     _add_cstar_arguments_without_command(continue_parser)
     _add_ssh_arguments(continue_parser)
     _add_jmx_auth_arguments(continue_parser)
+    _add_raw_jmx_args(continue_parser)
 
     cleanup_parser = subparsers.add_parser('cleanup-jobs', help='Cleanup old finished jobs and exit (*)')
     cleanup_parser.set_defaults(func=execute_cleanup)
@@ -110,6 +111,7 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
     _add_cstar_arguments_without_command(cleanup_parser)
     _add_ssh_arguments(cleanup_parser)
     _add_jmx_auth_arguments(cleanup_parser)
+    _add_raw_jmx_args(cleanup_parser)
 
     for (name, command) in commands.items():
         command_parser = subparsers.add_parser(name, help=command.description)
@@ -120,6 +122,7 @@ def add_cstar_arguments(parser, commands, execute_command, execute_continue, exe
         _add_common_arguments(command_parser)
         _add_ssh_arguments(command_parser)
         _add_jmx_auth_arguments(command_parser)
+        _add_raw_jmx_args(command_parser)
         command_parser.set_defaults(func=lambda args: execute_command(args), command=command)
 
 
@@ -130,6 +133,7 @@ def add_cstarpar_arguments(parser):
     _add_strategy_arguments(parser)
     _add_ssh_arguments(parser)
     _add_jmx_auth_arguments(parser)
+    _add_raw_jmx_args(parser)
     parser.add_argument('command', help='Command to run once for each Cassandra host')
 
 def _add_ssh_arguments(parser):
@@ -140,3 +144,6 @@ def _add_ssh_arguments(parser):
 def _add_jmx_auth_arguments(parser):
     parser.add_argument('--jmx-username', help='JMX username', default=None)
     parser.add_argument('--jmx-passwordfile', help='JMX passwordfile', default=None)
+
+def _add_raw_jmx_args(parser):
+    parser.add_argument('--jmx-addlargs', help='Any additional JMX args', default=None)

--- a/cstar/cstarcli.py
+++ b/cstar/cstarcli.py
@@ -142,6 +142,7 @@ def execute_command(args):
             jmx_username=args.jmx_username,
             jmx_password=args.jmx_password,
             jmx_passwordfile=args.jmx_passwordfile,
+            jmx_addlargs=args.jmx_addlargs,
             resolve_hostnames=args.resolve_hostnames,
             hosts_variables=hosts_variables)
         job.run()
@@ -223,6 +224,9 @@ def main():
         namespace.jmx_password = getpass.getpass(prompt="JMX Password ")
     else:
         namespace.jmx_password = None
+
+    if namespace.jmx_addlargs:
+        namespace.jmx_addlargs = namespace.jmx_addlargs.strip('\\')
 
     cstar.output.configure(namespace.verbose)
     namespace.func(namespace)

--- a/cstar/cstarparcli.py
+++ b/cstar/cstarparcli.py
@@ -55,6 +55,9 @@ def main():
     else:
         namespace.jmx_password = None
 
+    if namespace.jmx_addlargs:
+        namespace.jmx_addlargs = namespace.jmx_addlargs.strip('\\')
+
     if bool(namespace.seed_host) + bool(namespace.host) + bool(namespace.host_file) != 1:
         error("Exactly one of --seed-host, --host and --host-file must be used", print_traceback=False)
 
@@ -110,6 +113,7 @@ def main():
             jmx_username=namespace.jmx_username,
             jmx_password=namespace.jmx_password,
             jmx_passwordfile=namespace.jmx_passwordfile,
+            jmx_addlargs=namespace.jmx_addlargs,
             resolve_hostnames=namespace.resolve_hostnames,
             hosts_variables=hosts_variables)
         job.run()

--- a/cstar/job.py
+++ b/cstar/job.py
@@ -76,6 +76,7 @@ class Job(object):
         self.jmx_username = None
         self.jmx_password = None
         self.jmx_passwordfile = None
+        self.jmx_addlargs = None
         self.hosts_variables = dict()
         self.returned_jobs = list()
         self.schema_versions = list()
@@ -106,7 +107,6 @@ class Job(object):
         for host in seed_nodes:
             tried_hosts.append(host)
             conn = self._connection(host)
-
             describe_res = self.run_nodetool(conn, "describecluster")
             status_res = self.run_nodetool(conn, "status")
             if (describe_res.status == 0) and (status_res.status == 0):
@@ -240,6 +240,9 @@ class Job(object):
                 jmx_args.extend(["-pw", self.jmx_password])
             if self.jmx_passwordfile:
                 jmx_args.extend(["-pwf", self.jmx_passwordfile])
+            if self.jmx_addlargs:
+                split_jmx_addlargs=self.jmx_addlargs.split()
+                jmx_args.extend(split_jmx_addlargs)
 
         return conn.run((*sudo, "nodetool", *jmx_args, *cmds))
 
@@ -248,7 +251,7 @@ class Job(object):
               ignore_down_nodes, dc_filter,
               sleep_on_new_runner, sleep_after_done,
               ssh_username, ssh_password, ssh_identity_file, ssh_lib,
-              jmx_username, jmx_password, jmx_passwordfile, resolve_hostnames, hosts_variables):
+              jmx_username, jmx_password, jmx_passwordfile, jmx_addlargs, resolve_hostnames, hosts_variables):
 
         msg("Starting setup")
 
@@ -275,6 +278,7 @@ class Job(object):
         self.jmx_username = jmx_username
         self.jmx_password = jmx_password
         self.jmx_passwordfile = jmx_passwordfile
+        self.jmx_addlargs = jmx_addlargs
         self.resolve_hostnames = resolve_hostnames
         self.hosts_variables = hosts_variables
         if not os.path.exists(self.output_directory):

--- a/cstar/jobreader.py
+++ b/cstar/jobreader.py
@@ -69,6 +69,7 @@ def _parse(input, file, output_directory, job, job_id, stop_after, max_days, end
     job.sudo_args = data['sudo_args']
     job.jmx_username = data['jmx_username']
     job.jmx_passwordfile = data['jmx_passwordfile']
+    job.addl_jmx_args = data['addl_jmx_args']
     job.hosts_variables = data['hosts_variables']
 
     strategy = cstar.strategy.parse(state['strategy'])

--- a/tests/jobreader_test.py
+++ b/tests/jobreader_test.py
@@ -140,6 +140,7 @@ def get_example_file():
     "timeout": null,
     "jmx_username": null,
     "jmx_passwordfile": null,
+    "addl_jmx_args": null,
     "use_sudo": "false",
     "version": 8,
     "hosts_variables": null

--- a/tests/resources/failed_job.json
+++ b/tests/resources/failed_job.json
@@ -105,6 +105,7 @@
     "timeout": null,
     "jmx_username": null,
     "jmx_passwordfile": null,
+    "jmx_addlargs": null,
     "use_sudo": false,
     "version": 8,
     "hosts_variables": null


### PR DESCRIPTION
This allows users to set arbitrary jmx args for passing into nodetool for cluster identification.
eg --jmx-addlargs '\-Dcom.sun.jndi.rmiURLParsing=legacy'

This does not fix individual command scripts that cstar would execute, but those can be updated by users as necessary.
